### PR TITLE
Define STRICT_R_HEADERS, change PI to M_PI

### DIFF
--- a/src/compute_groupcond_logl.cpp
+++ b/src/compute_groupcond_logl.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 using namespace Rcpp;
 
@@ -41,7 +42,7 @@ double compute_groupcond_logl(NumericMatrix x,
   int wn = dims[3];
   
   // constants
-  double sqrtpi = std::sqrt(2*PI);
+  double sqrtpi = std::sqrt(2*M_PI);
   double cz = std::pow(sqrtpi, zn);
   double cw = std::pow(sqrtpi, wn);
   

--- a/src/creg_group_logl.cpp
+++ b/src/creg_group_logl.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 using namespace Rcpp;
 
@@ -54,7 +55,7 @@ NumericVector creg_group_logl_cpp(List datalist, List modellist){
         int wn = dims[3];
         
         // constants
-        double sqrtpi = std::sqrt(2*PI);
+        double sqrtpi = std::sqrt(2*M_PI);
         double cz = std::pow(sqrtpi, zn);
         double cw = std::pow(sqrtpi, wn);
         


### PR DESCRIPTION
Dear Christoph,

Your CRAN package lavacreg uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context on this.

Here, we prefixed two #include <Rcpp.h> with STRICT_R_HEADERS. The actual change that is needed is the change from PI to M_PI in two files.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by https://github.com/RcppCore/Rcpp/issues/1158 to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.